### PR TITLE
Remove call to assign_params

### DIFF
--- a/HARK/hark_portfolio_agents.py
+++ b/HARK/hark_portfolio_agents.py
@@ -87,11 +87,6 @@ def distribute(agents, dist_params):
             for agent in agent_dist
         ]
 
-        # should be unecessary but a hack to cover a HARK bug
-        # https://github.com/econ-ark/HARK/issues/994
-        for agent in agents:
-            agent.assign_parameters(**{param : getattr(agent, param)})
-
     return agents
 
 #####

--- a/HARK/requirements.txt
+++ b/HARK/requirements.txt
@@ -1,4 +1,4 @@
-econ-ark
+git+https://github.com/econ-ark/HARK@master#egg=econ-ark
 jpype1
 matplotlib
 numpy


### PR DESCRIPTION
Removes the hacky call to `assign_params`, which is already covered by `distribute_params` in the latest HARK pull request merge. 

As a side effect, the master branch of `econ-ark/HARK` is now used in `requirements.txt` instead of the latest release. 

Addresses #5 