### PR TITLE
New Stats

### DIFF
--- a/HARK/study_data.py
+++ b/HARK/study_data.py
@@ -3,6 +3,7 @@ import io
 import os
 import pandas as pd
 import re
+import argparse
 
 prefix = " 004-48-attn-study"
 blobs = azure_storage.list_blobs(name_starts_with=prefix)
@@ -22,9 +23,14 @@ def tre_data(blob):
 
     return df
 
-dfs = [tre_data(blob) for blob in blobs]
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Study saved data from a simulation')
+    parser.add_argument('--prefix', default=" 004-48-attn-study")
+    args = parser.parse_args()
 
-tdf = pd.concat(dfs)
+    dfs = [tre_data(blob) for blob in blobs]
 
-tdf.to_csv(f"{prefix.lstrip()}-all_records.csv")
+    tdf = pd.concat(dfs)
+
+    tdf.to_csv(f"{args.prefix.lstrip()}-all_records.csv")
 

--- a/HARK/tests/test_portfolio_agents.py
+++ b/HARK/tests/test_portfolio_agents.py
@@ -48,7 +48,7 @@ def test_agent_population():
         'PermShkStd' : [ssvp['PermShkStd'][idx_27] ** 0.25]
     }
 
-
+    n_per_class = 1
 
     pop = hpa.AgentPopulation(agent_parameters, dist_params, n_per_class)
     
@@ -62,7 +62,7 @@ def test_agent_population():
     pop.init_simulation()
 
     # arguments to attention simulation
-    n_per_class = 1
+    
     a = 0.2
     q = 1
     r = 1


### PR DESCRIPTION
Adds `ror_mean`, `total_population_aLvl_mean`, and `total_population_aLvl_std` to `sim_stats`. The latter two are done by adding an attribute, `total_pop_stats`, to `AgentPopulation.history`, which tracks individual agents instead of aggregate statistics. The statistics from the final period are then aggregated across the whole population in `sim_stats()`